### PR TITLE
Allow upto `10` PRs to be opened by `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,5 @@ updates:
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
-    # Allow up to 10 open pull requests for pip dependencies
+    # Allow up to 10 open pull requests for npm dependencies
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
+    # Allow up to 10 open pull requests for pip dependencies
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Context of Change
Allow upto `10` PRs to be opened by `dependabot`
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [X] Chore (project configuration, scripts, dotfiles, etc.)
